### PR TITLE
Added method so Model::create will properly translate camelCased attributes

### DIFF
--- a/src/Database/Traits/CamelCaseModel.php
+++ b/src/Database/Traits/CamelCaseModel.php
@@ -122,6 +122,24 @@ trait CamelCaseModel
 	}
 
     /**
+     * Properly translates keys to snake_case when using Model::create($attributes) and returns the instance
+     *
+     * @param array $attributes
+     * @return static
+     */
+
+    public static function create(array $attributes)
+    {
+        $new_attributes = [];
+
+        array_walk($attributes, function($value, $key) use (&$new_attributes) {
+            $new_attributes[snake_case($key)] = $value;
+        });
+
+        return parent::create($new_attributes);
+    }
+
+    /**
      * Because we are changing the case of keys and want to use camelCase throughout the application, whenever
      * we do isset checks we need to ensure that we check using snake_case.
      *

--- a/src/Database/Traits/CamelCaseModel.php
+++ b/src/Database/Traits/CamelCaseModel.php
@@ -122,22 +122,26 @@ trait CamelCaseModel
 	}
 
     /**
-     * Properly translates keys to snake_case when using Model::create($attributes) and returns the instance
+     * Fill the model with an array of attributes and properly translates keys
+     * to snake_case when using Model::fill($attributes) and returns the instance
      *
-     * @param array $attributes
-     * @return static
+     * @param  array  $attributes
+     * @return $this
+     *
+     * @throws \Illuminate\Database\Eloquent\MassAssignmentException
      */
 
-    public static function create(array $attributes)
+    public function fill(array $attributes)
     {
         $new_attributes = [];
 
-        array_walk($attributes, function($value, $key) use (&$new_attributes) {
-            $new_attributes[snake_case($key)] = $value;
+        array_walk($attributes, function ($value, $key) use (&$new_attributes) {
+            $new_attributes[$this->getTrueKey($key)] = $value;
         });
 
-        return parent::create($new_attributes);
+        return parent::fill($new_attributes);
     }
+
 
     /**
      * Because we are changing the case of keys and want to use camelCase throughout the application, whenever

--- a/tests/Database/Traits/CamelCaseModelTest.php
+++ b/tests/Database/Traits/CamelCaseModelTest.php
@@ -60,4 +60,26 @@ class CamelCaseModelTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedAttributes, $this->model->attributesToArray());
     }
+
+    public function testCreatingModelByUsingCreate()
+    {
+        $attributes = [
+            'address' => 'Home',
+            'countryOfOrigin' => 'Australia',
+            'firstName' => 'Kirk',
+            'lastName' => 'Bushell'
+        ];
+
+        $expectedAttributes = [
+            'address' => 'Home',
+            'country_of_origin' => 'Australia',
+            'first_name' => 'Kirk',
+            'last_name' => 'Bushell'
+        ];
+
+        $model = ModelStub::create($attributes); //Create local instance of ModelStub since we are testing an alternative method of creating a model.
+
+        $this->assertEquals($expectedAttributes, $model->rawAttributesToArray());
+
+    }
 }

--- a/tests/Stubs/ParentModelStub.php
+++ b/tests/Stubs/ParentModelStub.php
@@ -11,7 +11,29 @@ class ParentModelStub
         'country_of_origin' => 'Australia'
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        if(!empty($attributes)) {
+            $this->attributes = [];
+            $this->fill($attributes);
+        }
+    }
+
+    public function fill(array $attributes)
+    {
+        foreach ($attributes as $key => $value)
+        {
+            $this->setAttribute($key, $value);
+        }
+
+    }
+
     public function attributesToArray()
+    {
+        return $this->attributes;
+    }
+
+    public function rawAttributesToArray()
     {
         return $this->attributes;
     }
@@ -24,5 +46,10 @@ class ParentModelStub
     public function setAttribute($key, $value)
     {
         $this->attributes[$key] = $value;
+    }
+
+    public static function create(array $attributes)
+    {
+        return new static($attributes);
     }
 }


### PR DESCRIPTION
Some code of mine failed when using the CamelCaseModel because I was using Model::create() instead of assigning each attribute.

This code will make it so attributes are properly translated when using create() with the CamelCaseModel trait.