### PR TITLE
Checking for null $foreignKey and skipping update.

### DIFF
--- a/src/Behaviours/CountCache/CountCacheManager.php
+++ b/src/Behaviours/CountCache/CountCacheManager.php
@@ -80,6 +80,10 @@ class CountCacheManager
      */
     protected function update(array $config, $operation, $foreignKey)
     {
+        if (is_null($foreignKey)) {
+            return;
+        }
+
         $table = $this->getTable($config['model']);
 
         // the following is required for camel-cased models, in case users are defining their attributes as camelCase


### PR DESCRIPTION
As there may be cases where the foreignKey allows a null value, need to check for a non-null value before attempting to update the count cache.