### PR TITLE
Feature/camel case hidden and date fields

### DIFF
--- a/src/Database/Traits/CamelCaseModel.php
+++ b/src/Database/Traits/CamelCaseModel.php
@@ -68,6 +68,30 @@ trait CamelCaseModel
     {
         return $this->toCamelCase(parent::relationsToArray());
     }
+    
+    /**
+     * Overloads eloquent's getHidden method to ensure that hidden fields declared
+     * in camelCase are actually hidden and not exposed when models are turned
+     * into arrays.
+     *
+     * @return array
+     */
+    public function getHidden()
+    {
+        return array_map('snake_case', $this->hidden);
+    }
+
+    /**
+     * Overloads the eloquent getDates method to ensure that date field declarations
+     * can be made in camelCase but mapped to/from DB in snake_case.
+     *
+     * @return array
+     */
+    public function getDates()
+    {
+        $dates = parent::getDates();
+        return array_map('snake_case', $dates);
+    }
 
     /**
      * Converts a given array of attribute keys to the casing required by CamelCaseModel.

--- a/tests/Unit/Database/Traits/CamelCaseModelTest.php
+++ b/tests/Unit/Database/Traits/CamelCaseModelTest.php
@@ -95,4 +95,19 @@ class CamelCaseModelTest extends TestCase
         $model = new RealModelStub;
         $model->fakeRelationship;
     }
+
+    public function testModelHidesHiddenFields()
+    {
+        $model = new RealModelStub([
+            'myField' => 'value',
+            'anotherField' => 'yeah',
+            'someField' => 'whatever',
+            'hiddenField' => 'secrets!',
+        ]);
+
+        $modelArray = $model->toArray();
+
+        $this->assertFalse(isset($modelArray['hiddenField']));
+        $this->assertEquals('secrets!', $model->getAttribute('hiddenField'));
+    }
 }

--- a/tests/Unit/Database/Traits/CamelCaseModelTest.php
+++ b/tests/Unit/Database/Traits/CamelCaseModelTest.php
@@ -103,11 +103,15 @@ class CamelCaseModelTest extends TestCase
             'anotherField' => 'yeah',
             'someField' => 'whatever',
             'hiddenField' => 'secrets!',
+            'passwordHash' => '1234',
         ]);
 
         $modelArray = $model->toArray();
 
         $this->assertFalse(isset($modelArray['hiddenField']));
+        $this->assertFalse(isset($modelArray['passwordHash']));
+        
         $this->assertEquals('secrets!', $model->getAttribute('hiddenField'));
+        $this->assertEquals('1234', $model->getAttribute('passwordHash'));
     }
 }

--- a/tests/Unit/Database/Traits/CamelCaseModelTest.php
+++ b/tests/Unit/Database/Traits/CamelCaseModelTest.php
@@ -115,6 +115,27 @@ class CamelCaseModelTest extends TestCase
         $this->assertEquals('1234', $model->getAttribute('passwordHash'));
     }
 
+    public function testModelExposesHiddenFields()
+    {
+        $model = new RealModelStub([
+            'myField' => 'value',
+            'anotherField' => 'yeah',
+            'someField' => 'whatever',
+            'hiddenField' => 'secrets!',
+            'passwordHash' => '1234',
+        ]);
+
+        $modelArray = $model
+            ->withHidden(['hiddenField', 'password_hash'])
+            ->toArray();
+
+        $this->assertTrue(isset($modelArray['hiddenField']));
+        $this->assertTrue(isset($modelArray['passwordHash']));
+        
+        $this->assertEquals('secrets!', $modelArray['hiddenField']);
+        $this->assertEquals('1234', $modelArray['passwordHash']);
+    }
+
     public function testModelDateFieldHandling()
     {
         $model = new RealModelStub([

--- a/tests/Unit/Database/Traits/CamelCaseModelTest.php
+++ b/tests/Unit/Database/Traits/CamelCaseModelTest.php
@@ -114,4 +114,15 @@ class CamelCaseModelTest extends TestCase
         $this->assertEquals('secrets!', $model->getAttribute('hiddenField'));
         $this->assertEquals('1234', $model->getAttribute('passwordHash'));
     }
+
+    public function testModelDateFieldHandling()
+    {
+        $model = new RealModelStub([
+            'myField' => '2011-11-11T11:11:11Z',
+            'dateField' => '2011-11-11T11:11:11Z',
+        ]);
+
+        $this->assertFalse($model->myField instanceof \Carbon\Carbon);
+        $this->assertTrue($model->dateField instanceof \Carbon\Carbon);
+    }
 }

--- a/tests/Unit/Stubs/RealModelStub.php
+++ b/tests/Unit/Stubs/RealModelStub.php
@@ -8,9 +8,13 @@ use Eloquence\Database\Model;
 class RealModelStub extends Model implements CountCache
 {
 
+    protected $dateFormat = \DateTime::ISO8601;
+
+    protected $dates = ['dateField'];
+
     public $hidden = ['hiddenField', 'password_hash'];
 
-    public $fillable = ['myField', 'anotherField', 'some_field', 'hiddenField', 'passwordHash'];
+    public $fillable = ['myField', 'anotherField', 'some_field', 'hiddenField', 'passwordHash', 'dateField'];
 
     public function fakeRelationship()
     {

--- a/tests/Unit/Stubs/RealModelStub.php
+++ b/tests/Unit/Stubs/RealModelStub.php
@@ -7,7 +7,10 @@ use Eloquence\Database\Model;
 
 class RealModelStub extends Model implements CountCache
 {
-    public $fillable = ['myField', 'anotherField', 'some_field'];
+
+    public $hidden = ['hiddenField'];
+
+    public $fillable = ['myField', 'anotherField', 'some_field', 'hiddenField'];
 
     public function fakeRelationship()
     {

--- a/tests/Unit/Stubs/RealModelStub.php
+++ b/tests/Unit/Stubs/RealModelStub.php
@@ -8,9 +8,9 @@ use Eloquence\Database\Model;
 class RealModelStub extends Model implements CountCache
 {
 
-    public $hidden = ['hiddenField'];
+    public $hidden = ['hiddenField', 'password_hash'];
 
-    public $fillable = ['myField', 'anotherField', 'some_field', 'hiddenField'];
+    public $fillable = ['myField', 'anotherField', 'some_field', 'hiddenField', 'passwordHash'];
 
     public function fakeRelationship()
     {


### PR DESCRIPTION
Make the `CamelCaseModel` trait handle hidden and date fields that were declared in `camelCase`.

With this, any `$hidden` attributes in `camelCase` will not be visible when `toArray` is called on the model.

In addition, any `$dates` attributes declared in `camelCase` will be parsed into `Carbon` objects when set on the model.