### PR TITLE
Updating cache record when used with non-numeric primary keys bug.

### DIFF
--- a/src/Behaviours/Cacheable.php
+++ b/src/Behaviours/Cacheable.php
@@ -23,7 +23,7 @@ trait Cacheable
 
         $config = $this->processConfig($config);
 
-        $sql = "UPDATE `{$config['table']}` SET `{$config['field']}` = `{$config['field']}` {$operation} {$amount} WHERE `{$config['key']}` = {$foreignKey}";
+        $sql = "UPDATE `{$config['table']}` SET `{$config['field']}` = `{$config['field']}` {$operation} {$amount} WHERE `{$config['key']}` = '{$foreignKey}'";
 
         return DB::update($sql);
     }


### PR DESCRIPTION
If your table has non-numeric primary key (i.e. UUID) incorrect SQL is generated.

`Illuminate\Database\QueryException with message 'SQLSTATE[42S22]: Column not found: 1054 Unknown column '000ba0f1' in 'where clause' (SQL: UPDATE `users` SET `post_count` = `post_count` + 1 WHERE `id` = 000ba0f1-edd3-4e67-96cb-40c4ff701f67)'`