### PR TITLE
There should be a root namespace slash there.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ data from our Eloquent models persist through to our APIs in a camel-case manner
 if you are writing front-end applications, which are also using camelCase. This allows for a 
 better standard across our application. To use:
 
-    use Eloquence\Behaviours\CamelCasing;
+    use \Eloquence\Behaviours\CamelCasing;
 
 Put the above line in your models and that's it.
 


### PR DESCRIPTION
This is better, if you're not wanting to 'use' this trait on the top of your model file every time, and you just want to copy paste from the readme.