### PR TITLE
Make hashids/hashids dependency less restrictive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "hashids/hashids": "1.0.5",
+        "hashids/hashids": "^1.0",
         "illuminate/database": "~5.1",
-	    "ramsey/uuid": "^3.3",
+	"ramsey/uuid": "^3.3",
         "hanneskod/classtools": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
I can't install the package on multiple projects because it clashes with other packages that use hashid versions below or above your constraint.