### PR TITLE
Add a Force option to force-use the `rebuild` instead of the `update` method

### DIFF
--- a/src/Behaviours/Cacheable.php
+++ b/src/Behaviours/Cacheable.php
@@ -113,6 +113,7 @@ trait Cacheable
             'field'      => snake_case($config['field']),
             'key'        => snake_case($this->key($config['key'])),
             'foreignKey' => snake_case($this->key($config['foreignKey'])),
+            'force'      => $config['force']
         ];
     }
 

--- a/src/Behaviours/CountCache/CountCache.php
+++ b/src/Behaviours/CountCache/CountCache.php
@@ -112,7 +112,8 @@ class CountCache
             'model' => $relatedModel,
             'field' => $this->field($this->model, 'count'),
             'foreignKey' => $this->field($relatedModel, 'id'),
-            'key' => 'id'
+            'key' => 'id',
+            'force' => false
         ];
 
         return array_merge($defaults, $options);

--- a/src/Behaviours/CountCache/Countable.php
+++ b/src/Behaviours/CountCache/Countable.php
@@ -11,7 +11,11 @@ trait Countable
         static::created(function ($model) {
             $countCache = new CountCache($model);
             $countCache->apply(function ($config) use ($countCache, $model) {
-                $countCache->updateCacheRecord($config, '+', 1, $model->{$config['foreignKey']});
+                if ($config['force'] === true) {
+                    $countCache->rebuildCacheRecord($config, $model, 'COUNT');
+                } else {
+                    $countCache->updateCacheRecord($config, '+', 1, $model->{$config['foreignKey']});
+                }
             });
         });
 
@@ -22,7 +26,11 @@ trait Countable
         static::deleted(function ($model) {
             $countCache = new CountCache($model);
             $countCache->apply(function ($config) use ($countCache, $model) {
-                $countCache->updateCacheRecord($config, '-', 1, $model->{$config['foreignKey']});
+                if ($config['force'] === true) {
+                    $countCache->rebuildCacheRecord($config, $model, 'COUNT');
+                } else {
+                    $countCache->updateCacheRecord($config, '-', 1, $model->{$config['foreignKey']});
+                }
             });
         });
     }

--- a/src/Behaviours/SumCache/SumCache.php
+++ b/src/Behaviours/SumCache/SumCache.php
@@ -117,7 +117,8 @@ class SumCache
             'columnToSum' => 'total',
             'field' => $this->field($this->model, 'total'),
             'foreignKey' => $this->field($relatedModel, 'id'),
-            'key' => 'id'
+            'key' => 'id',
+            'force' => false
         ];
 
         return array_merge($defaults, $options);

--- a/tests/Acceptance/CountCacheTest.php
+++ b/tests/Acceptance/CountCacheTest.php
@@ -22,6 +22,20 @@ class CountCacheTest extends AcceptanceTestCase
         $this->assertEquals(1, $user->postCountExplicit);
     }
 
+    public function testUserCountCacheWithForce()
+    {
+        User::where('id', $this->data['user']->id)->update(['comment_count' => 1337]);
+
+        $comment = new Comment;
+        $comment->userId = $this->data['user']->id;
+        $comment->postId = $this->data['post']->id;
+        $comment->save();
+
+        $user = User::first();
+
+        $this->assertEquals(1, $user->commentCount);
+    }
+
     public function testComplexCountCache()
     {
         $post = new Post;

--- a/tests/Acceptance/Models/Comment.php
+++ b/tests/Acceptance/Models/Comment.php
@@ -14,7 +14,10 @@ class Comment extends Model
     {
         return [
             'Tests\Acceptance\Models\Post',
-            'Tests\Acceptance\Models\User',
+            [
+                'model' => 'Tests\Acceptance\Models\User',
+                'force' => true
+            ]
         ];
     }
 }


### PR DESCRIPTION
I think it should be nice to have a `force` option (default to `false`) to permit to use the `rebuildCacheRecord` method instead of the `updateCacheRecord` :
```php
'force' => true
```

Because for me, a counter cache based only on an increment/decrement is not very efficient and can cause some issues in some cases. Of course this option can be applied to the Sum Behavior also.

This PR is only to show you the feature (with tests btw) i'm pretty sure you will implement it better then me. ^^