### PR TITLE
Fix issue where relations with camel case

### DIFF
--- a/src/Behaviours/CamelCasing.php
+++ b/src/Behaviours/CamelCasing.php
@@ -188,7 +188,7 @@ trait CamelCasing
      */
     public function __isset($key)
     {
-        return parent::__isset($this->getSnakeKey($key));
+        return parent::__isset($key) || parent::__isset($this->getSnakeKey($key));
     }
 
     /**


### PR DESCRIPTION
Issue occurs when a relation has camel case, and isset() is called. 
It returns false as the key is converted to snake case.
    
For example `$model->relatedModel` is checked as `$model->related_model`.