### PR TITLE
Ensure slug is unique with quick exists db check

### DIFF
--- a/src/Behaviours/Slug.php
+++ b/src/Behaviours/Slug.php
@@ -39,6 +39,26 @@ class Slug implements Jsonable
     }
 
     /**
+     * Generate a new entirely random 8-character slug
+     *
+     * @return Slug
+     */
+    public static function random()
+    {
+        $exclude = ['/', '+', '=', 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        $length = 8;
+        $string = '';
+
+        while (($len = strlen($string)) < $length) {
+            $size = $length - $len;
+            $bytes = random_bytes($size);
+            $string .= substr(str_replace($exclude, '', base64_encode($bytes)), 0, $size);
+        }
+
+        return new Slug($string);
+    }
+
+    /**
      * Creates a new slug from a string title.
      *
      * @param string $title

--- a/src/Exceptions/UnableToCreateSlugException.php
+++ b/src/Exceptions/UnableToCreateSlugException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Eloquence\Exceptions;
+
+class UnableToCreateSlugException extends \Exception
+{
+}

--- a/tests/Unit/Behaviours/SlugTest.php
+++ b/tests/Unit/Behaviours/SlugTest.php
@@ -1,0 +1,13 @@
+<?php
+namespace tests\Unit\Database\Traits;
+
+use Eloquence\Behaviours\Slug;
+use Tests\Unit\TestCase;
+
+class SlugTest extends TestCase
+{
+    public function test_random_slug_is_random()
+    {
+        $this->assertNotEquals(Slug::random(), Slug::random());
+    }
+}


### PR DESCRIPTION
Since the `Slug::fromId()` algorithm doesn't produce unique slugs, this adds in a uniqueness check that will attempt to generate a new random slug instead. 

I've added in a limit of 10 attempts, to avoid a potential 100+ loop slug search, which would slow down the process a fair bit. I think it's better to notify the developer that there are issues with slugs - which should only happen for a really large dataset.

I added the `Slug::random()` helper to generate truly random slug values. I based it off the Laravel `str_random()` code, with the additional limitation of only `a-zA-Z`.

It would be good to refactor `fromId()` out, as all it does is generate random slugs that aren't linked to `id` anyway. Also the use of `md5()` and `uniqid()` make it relatively insecure via brute-force guesswork.