### PR TITLE
Laravel 5.5/5.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7
+  - 7.0
+  - 7.1
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     "require": {
         "php": ">=7.1.3",
         "hashids/hashids": "^1.0",
-        "illuminate/database": "~5.6",
+        "illuminate/database": "~5.5",
         "ramsey/uuid": "^3.3",
         "hanneskod/classtools": "~1.0"
     },
     "require-dev": {
-        "illuminate/events": "~5.6",
+        "illuminate/events": "~5.5",
         "mockery/mockery": "1.1.0",
         "orchestra/testbench": "3.6.*",
         "phpunit/phpunit": "7.2.*"

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,17 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1.3",
         "hashids/hashids": "^1.0",
-        "illuminate/database": "~5.1",
-	"ramsey/uuid": "^3.3",
+        "illuminate/database": "~5.6",
+        "ramsey/uuid": "^3.3",
         "hanneskod/classtools": "~1.0"
     },
     "require-dev": {
-        "illuminate/events": "~5.0",
-        "mockery/mockery": "0.9.*@dev",
-        "orchestra/testbench": "3.1.*",
-        "phpunit/phpunit": "4.3.*"
+        "illuminate/events": "~5.6",
+        "mockery/mockery": "1.1.0",
+        "orchestra/testbench": "3.6.*",
+        "phpunit/phpunit": "7.2.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
+        "php": ">=7.0",
         "hashids/hashids": "^1.0",
         "illuminate/database": "~5.5",
         "ramsey/uuid": "^3.3",
@@ -18,8 +18,8 @@
     "require-dev": {
         "illuminate/events": "~5.5",
         "mockery/mockery": "1.1.0",
-        "orchestra/testbench": "3.6.*",
-        "phpunit/phpunit": "7.2.*"
+        "orchestra/testbench": "3.5.*",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="unit">

--- a/src/Behaviours/CamelCasing.php
+++ b/src/Behaviours/CamelCasing.php
@@ -50,16 +50,6 @@ trait CamelCasing
     }
 
     /**
-     * Converts the attributes to a camel-case version, if applicable.
-     *
-     * @return array
-     */
-    public function getAttributes($keys = [])
-    {
-        return $this->attributesToArray();
-    }
-
-    /**
      * Get the model's relationships, converting field casing if necessary.
      *
      * @return array
@@ -109,18 +99,6 @@ trait CamelCasing
         }
 
         return $convertedAttributes;
-    }
-
-    /**
-     * Get the model's original attribute values.
-     *
-     * @param  string  $key
-     * @param  mixed   $default
-     * @return array
-     */
-    public function getOriginal($key = null, $default = null)
-    {
-        return array_get($this->toCamelCase($this->original), $key, $default);
     }
 
     /**

--- a/src/Behaviours/CountCache/CountCache.php
+++ b/src/Behaviours/CountCache/CountCache.php
@@ -39,7 +39,7 @@ class CountCache
     public function update()
     {
         $this->apply(function ($config) {
-            $foreignKey = $this->key($config['foreignKey']);
+            $foreignKey = snake_case($this->key($config['foreignKey']));
 
             if ($this->model->getOriginal($foreignKey) && $this->model->{$foreignKey} != $this->model->getOriginal($foreignKey)) {
                 $this->updateCacheRecord($config, '-', 1, $this->model->getOriginal($foreignKey));

--- a/src/Behaviours/SumCache/SumCache.php
+++ b/src/Behaviours/SumCache/SumCache.php
@@ -49,7 +49,7 @@ class SumCache
     public function update()
     {
         $this->apply(function ($config) {
-            $foreignKey = $this->key($config['foreignKey']);
+            $foreignKey = snake_case($this->key($config['foreignKey']));
             $amount = $this->model->{$config['columnToSum']};
 
             if ($this->model->getOriginal($foreignKey) && $this->model->{$foreignKey} != $this->model->getOriginal($foreignKey)) {

--- a/tests/Unit/Database/Traits/CamelCaseModelTest.php
+++ b/tests/Unit/Database/Traits/CamelCaseModelTest.php
@@ -40,20 +40,6 @@ class CamelCaseModelTest extends TestCase
         $this->assertEquals('Kirk', $this->model->getAttribute('firstName'));
     }
 
-    public function test_array_retrieval_of_attributes()
-    {
-        $expectedArray = [
-            'firstName' => 'Kirk',
-            'lastName' => 'Bushell',
-            'address' => 'Home',
-            'countryOfOrigin' => 'Australia'
-        ];
-
-        $actualArray = $this->model->getAttributes();
-
-        $this->assertEquals($expectedArray, $actualArray);
-    }
-
     public function test_attribute_conversion()
     {
         $expectedAttributes = [

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,10 +1,10 @@
 <?php
 namespace tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
 use Mockery as m;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
This pull request upgrades Eloquence to make it compatible with Laravel 5.6.

As discussed in https://github.com/kirkbushell/eloquence/issues/68 the `getAttributes` and `getOriginal` methods will no longer be overridden. It seems like it's a breaking but necessary change and that's why it should be properly documented in the Changelog if you decide to merge it in. @kirkbushell 

As part of the upgrade the `CountCache` and `SumCache` classes were updated too, so that the key is passed to the `getOriginal` method in the correct case. At this point all tests are passing.
