### PR TITLE
Laravel 6.0 Compatability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,18 +9,18 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.0",
         "hashids/hashids": "^1.0",
-        "illuminate/database": "~6.0",
+        "illuminate/database": "~5.5||~6.0",
         "ramsey/uuid": "^3.3",
-        "hanneskod/classtools": "~1.0",
-        "laravel/helpers": "^1.1"
+        "hanneskod/classtools": "~1.0"
     },
     "require-dev": {
-        "illuminate/events": "~6.0",
-        "mockery/mockery": "~1.2.3",
-        "orchestra/testbench": "~4.0.0",
-        "phpunit/phpunit": "~8.0"
+        "illuminate/events": "~5.5||~6.0",
+        "mockery/mockery": "1.1.0||~1.2.3",
+        "orchestra/testbench": "3.5.*||~4.0.0",
+        "laravel/helpers": "^1.1",
+        "phpunit/phpunit": "~6.0||~8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,18 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.2",
         "hashids/hashids": "^1.0",
-        "illuminate/database": "~5.5",
+        "illuminate/database": "~6.0",
         "ramsey/uuid": "^3.3",
-        "hanneskod/classtools": "~1.0"
+        "hanneskod/classtools": "~1.0",
+        "laravel/helpers": "^1.1"
     },
     "require-dev": {
-        "illuminate/events": "~5.5",
-        "mockery/mockery": "1.1.0",
-        "orchestra/testbench": "3.5.*",
-        "phpunit/phpunit": "~6.0"
+        "illuminate/events": "~6.0",
+        "mockery/mockery": "~1.2.3",
+        "orchestra/testbench": "~4.0.0",
+        "phpunit/phpunit": "~8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Acceptance/AcceptanceTestCase.php
+++ b/tests/Acceptance/AcceptanceTestCase.php
@@ -7,7 +7,7 @@ use Orchestra\Testbench\TestCase;
 
 class AcceptanceTestCase extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -6,14 +6,14 @@ use Mockery as m;
 
 class TestCase extends PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 
         $this->init();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }


### PR DESCRIPTION
This pull request upgrades Eloquence to be compatible with Laravel 6.0

Due to the **str_** and **array_** helpers being moved to their own package in Laravel 6.0, I added the `laravel/helpers` package as a development requirement.

All of the included test cases pass.

