### PR TITLE
Update ramsey/uuid constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "hashids/hashids": "^1.0",
         "illuminate/database": "~7.0",
         "illuminate/support": "~7.0",
-        "ramsey/uuid": "^3.3",
+        "ramsey/uuid": "^3.3|^4.0",
         "hanneskod/classtools": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 7 uses `"ramsey/uuid": "^3.7|^4.0"` as its constraint, and so a fresh install now installs v4.0.1. Eloquence won't install on top of that as it is constraint is `^3.3`. All tests still pass after updating.