### PR TITLE
allow mass assignment of camelCased fields

### DIFF
--- a/src/Behaviours/CamelCasing.php
+++ b/src/Behaviours/CamelCasing.php
@@ -14,6 +14,18 @@ trait CamelCasing
     public $enforceCamelCase = true;
 
     /**
+     * Overloads the eloquent isGuardableColumn method to ensure that we are checking for the existence of
+     * the snake_cased column name.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isGuardableColumn($key)
+    {
+        return parent::isGuardableColumn($this->getSnakeKey($key));
+    }
+
+    /**
      * Overloads the eloquent setAttribute method to ensure that fields accessed
      * in any case are converted to snake_case, which is the defacto standard
      * for field names in databases.

--- a/tests/Acceptance/GuardedColumnsTest.php
+++ b/tests/Acceptance/GuardedColumnsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Acceptance;
+
+use Tests\Acceptance\Models\GuardedUser;
+
+class GuardedColumnsTest extends AcceptanceTestCase
+{
+    public function testGuardedUser()
+    {
+        $user = GuardedUser::create([
+            'firstName' => 'Stuart',
+            'last_name' => 'Jones',
+        ]);
+
+        $this->assertEquals('Stuart', $user->firstName);
+        $this->assertEquals('Jones', $user->lastName);
+    }
+}

--- a/tests/Acceptance/Models/GuardedUser.php
+++ b/tests/Acceptance/Models/GuardedUser.php
@@ -1,0 +1,19 @@
+<?php
+namespace Tests\Acceptance\Models;
+
+use Eloquence\Behaviours\CamelCasing;
+use Illuminate\Database\Eloquent\Model;
+
+class GuardedUser extends Model
+{
+    use CamelCasing;
+
+    protected $table = 'users';
+
+    /**
+     * The attributes that are protected from mass assignment.
+     *
+     * @var array
+     */
+    protected $guarded = ['id'];
+}


### PR DESCRIPTION
Overload the Eloquent `isGuardableColumn` to convert camelCased field names into snake_cased column names to re-enable mass assignment to these fields.

Fixes #80 