### PR TITLE
update to laravel 8 (and php 7.3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,17 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.3",
         "hashids/hashids": "^1.0",
-        "illuminate/database": "~7.0",
-        "illuminate/support": "~7.0",
+        "illuminate/database": "~8.0",
+        "illuminate/support": "~8.0",
         "ramsey/uuid": "^4",
         "hanneskod/classtools": "~1.0"
     },
     "require-dev": {
-        "illuminate/events": "~7.0",
+        "illuminate/events": "~8.0",
         "mockery/mockery": "^1.3.0",
-        "orchestra/testbench": "~5",
+        "orchestra/testbench": "~6",
         "phpunit/phpunit": "~8.0"
     },
     "autoload": {


### PR DESCRIPTION
Updated illuminate dependencies to ~8.0
Updated orchestra/testbench to ~6.0 (required to support illluminate 8)
Updated PHP minimum requirement to 7.3 (required to support illuminate 8)

Closes #82 