### PR TITLE
Remove 7.2 from test environments in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
   - 7.4
 


### PR DESCRIPTION
Looks like I missed the travis setup when bumping the minimum PHP to 7.3 (needed for Laravel 8). Sorry about that.