### PR TITLE
setAttribute of CamelCasing changes contract

### DIFF
--- a/src/Behaviours/CamelCasing.php
+++ b/src/Behaviours/CamelCasing.php
@@ -32,10 +32,11 @@ trait CamelCasing
      *
      * @param string $key
      * @param mixed  $value
+     * @return mixed
      */
     public function setAttribute($key, $value)
     {
-        parent::setAttribute($this->getSnakeKey($key), $value);
+        return parent::setAttribute($this->getSnakeKey($key), $value);
     }
 
     /**


### PR DESCRIPTION
Closes kirkbushell/eloquence#85 (see the issue for description)

Are there any potential dangers with adding the `return`?

