### PR TITLE
chore: update hashids/hashids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "hashids/hashids": "^1.0",
+        "hashids/hashids": "^4.0",
         "illuminate/database": "~8.0",
         "illuminate/support": "~8.0",
         "ramsey/uuid": "^4",


### PR DESCRIPTION
`hashids/hashids`'s version is fairly old. Can we upgrade it?