### PR TITLE
Add transaction to Cacheable increment and decrement

### DIFF
--- a/src/Behaviours/Cacheable.php
+++ b/src/Behaviours/Cacheable.php
@@ -30,19 +30,19 @@ trait Cacheable
          * Increment for + operator
          */
         if ($operation == '+') {
-            DB::transaction(function () use ($sql, $config, $amount) {
-                $sql->increment($config['field'], $amount);
+            DB::transaction(function () use ($sql, $config, $amount, &$result) {
+                $result = $sql->increment($config['field'], $amount);
             });
-            return null;
+            return $result;
         }
 
         /*
          * Decrement for - operator
          */
-        DB::transaction(function () use ($sql, $config, $amount) {
-            $sql->decrement($config['field'], $amount);
+        DB::transaction(function () use ($sql, $config, $amount, &$result) {
+            $result = $sql->decrement($config['field'], $amount);
         });
-        return null;
+        return $result;
     }
 
     /**

--- a/src/Behaviours/Cacheable.php
+++ b/src/Behaviours/Cacheable.php
@@ -30,13 +30,19 @@ trait Cacheable
          * Increment for + operator
          */
         if ($operation == '+') {
-            return $sql->increment($config['field'], $amount);
+            DB::transaction(function () use ($sql, $config, $amount) {
+                $sql->increment($config['field'], $amount);
+            });
+            return null;
         }
 
         /*
          * Decrement for - operator
          */
-        return $sql->decrement($config['field'], $amount);
+        DB::transaction(function () use ($sql, $config, $amount) {
+            $sql->decrement($config['field'], $amount);
+        });
+        return null;
     }
 
     /**


### PR DESCRIPTION
It may happen that rapid incrementing/decrementing of count cache produces invalid values. Using a transaction to prevent it.