### PR TITLE
Error when the slug attribute is not defined in the model

### DIFF
--- a/src/Behaviours/Sluggable.php
+++ b/src/Behaviours/Sluggable.php
@@ -3,6 +3,7 @@ namespace Eloquence\Behaviours;
 
 use Eloquence\Behaviours\Slug;
 use Eloquence\Exceptions\UnableToCreateSlugException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait Sluggable
@@ -170,7 +171,7 @@ trait Sluggable
      */
     public function getSlugAttribute()
     {
-        return new Slug($this->attributes[$this->slugField()]);
+        return new Slug(Arr::get($this->attributes, $this->slugField()));
     }
 
     /**

--- a/tests/Acceptance/SluggedTest.php
+++ b/tests/Acceptance/SluggedTest.php
@@ -23,4 +23,11 @@ class SluggedTest extends AcceptanceTestCase
 
         $this->assertMatchesRegularExpression('/^[a-z0-9]{8}$/i', (string) $post->slug);
     }
+
+    public function testItReturnsNullWhenSlugIsNotSet(): void
+    {
+        $post = new Post;
+
+        $this->assertEquals('', (string) $post->slug);
+    }
 }


### PR DESCRIPTION
When the slug attribute is not defined in the model, it throws a `Undefined array key "slug"` error. 