### PR TITLE
Count cache support nullable

### DIFF
--- a/src/Behaviours/CountCache/CountCache.php
+++ b/src/Behaviours/CountCache/CountCache.php
@@ -44,7 +44,11 @@ class CountCache
             $originalRelatedModel = $config->emptyRelatedModel($this->model)->find($this->model->getOriginal($foreignKey));
 
             $this->updateCacheValue($originalRelatedModel, $config, -1);
-            $this->updateCacheValue($config->relatedModel($this->model), $config, 1);
+
+            // if the relation is null, then we don't need to do anything else.
+            if($this->model->{$foreignKey}) {
+                $this->updateCacheValue($config->relatedModel($this->model), $config, 1);
+            }
         });
     }
 

--- a/tests/Acceptance/CountCacheTest.php
+++ b/tests/Acceptance/CountCacheTest.php
@@ -43,4 +43,18 @@ class CountCacheTest extends AcceptanceTestCase
 
         $this->assertEquals(1, $post->fresh()->commentCount);
     }
+
+    public function testItCanHandleNullableRelation()
+    {
+        $user1 = User::factory()->create();
+        $posts = Post::factory()->count(2)->for($user1)->create();
+
+        $this->assertEquals(2, $user1->fresh()->postCount);
+
+        $firstPost = $posts->first()->fresh();
+        $firstPost->userId = null;
+        $firstPost->save();
+
+        $this->assertEquals(1, $user1->fresh()->postCount);
+    }
 }


### PR DESCRIPTION
When we use CountedBy on a nullable field and we set this to null:

```
...
$table->integer('user_id')->nullable();
...

$post->userId = null;
```

We receive an unexpected error: 
`TypeError : Eloquence\Behaviours\CacheConfig::relatedModel(): Return value must be of type Illuminate\Database\Eloquent\Model, null returned`

With this PR I've added a validation to avoid retrieving the model on the update method if the foreignKey value is null.

