### PR TITLE
Save models without behaviour-related model

### DIFF
--- a/src/Behaviours/CacheConfig.php
+++ b/src/Behaviours/CacheConfig.php
@@ -23,7 +23,7 @@ class CacheConfig
     /**
      * Returns the current related model.
      */
-    public function relatedModel(Model $model): Model
+    public function relatedModel(Model $model): ?Model
     {
         return $model->{$this->relationName};
     }

--- a/src/Behaviours/Cacheable.php
+++ b/src/Behaviours/Cacheable.php
@@ -109,8 +109,12 @@ trait Cacheable
     /**
      * Update the cache value for the model.
      */
-    protected function updateCacheValue(Model $model, CacheConfig $config, $value): void
+    protected function updateCacheValue(?Model $model, CacheConfig $config, $value): void
     {
+        if(!$model){
+            return;
+        }
+
         $model->{$config->aggregateField} = $model->{$config->aggregateField} + $value;
         $model->save();
     }

--- a/src/Behaviours/ValueCache/ValueCache.php
+++ b/src/Behaviours/ValueCache/ValueCache.php
@@ -39,7 +39,9 @@ class ValueCache
                 return;
             }
 
-            $relatedModel = $config->emptyRelatedModel($this->model)->find($this->model->$foreignKey);
+            if(!$relatedModel = $config->emptyRelatedModel($this->model)->find($this->model->$foreignKey)){
+                return;
+            }
 
             $relatedModel->{$config->aggregateField} = $this->model->{$config->sourceField};
             $relatedModel->save();

--- a/tests/Acceptance/CountCacheTest.php
+++ b/tests/Acceptance/CountCacheTest.php
@@ -57,4 +57,12 @@ class CountCacheTest extends AcceptanceTestCase
 
         $this->assertEquals(1, $user1->fresh()->postCount);
     }
+
+    public function test_canCreateModelWithoutRelatedBehavioursModels()
+    {
+        $post = new Post();
+        $post->save();
+
+        $this->assertModelExists($post);
+    }
 }


### PR DESCRIPTION
When you try to create a model without any behaviour-related(CountedBy, SummedBy, ValuedBy) model. It will throw an error as the observer triggers the increment for the related models.

As we are creating a model without any relation, is expected that the `relatedModel()` method returns a null value instead of a model.

I've introduced validations around this return type to handle this situation